### PR TITLE
Add Route Options Validation

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -11,8 +11,24 @@ const _ = require('lodash');
 let app;
 let fixturesDir;
 
+const validateResponse = function validateResponse(response) {
+  const payloadKeysPresent = [];
+  const payloadKeys = ['fixture', 'filePath', 'html', 'json', 'text'];
+
+  payloadKeys.forEach(key => {
+    if (response[key]) payloadKeysPresent.push(response[key]);
+  });
+
+  if (payloadKeysPresent.length > 1) {
+    throw new Error('Response options must not include more than one of the following: ' + payloadKeys.join(', '));
+  }
+};
+
 const handler = function handler(response) {
   response = response || {};
+
+  validateResponse(response);
+
   return (req, res) => {
     let send;
 

--- a/test/integration/response-test.js
+++ b/test/integration/response-test.js
@@ -8,6 +8,40 @@ const expect = require('chai').expect;
 describe('Response', () => {
   afterEach(() => mockyeah.reset());
 
+  it('should not allow for more than one response type', () => {
+    const payloadKeys = ['fixture', 'filePath', 'html', 'json', 'text'];
+    const optionSets = [
+      {
+        fixture: './test/fixtures/some-data.json',
+        filePath: './test/fixtures/some-data.csv'
+      },
+      {
+        fixture: './test/fixtures/some-data.json',
+        filePath: './test/fixtures/some-data.csv',
+        html: '<body></body>'
+      },
+      {
+        fixture: './test/fixtures/some-data.json',
+        filePath: './test/fixtures/some-data.csv',
+        html: '<body></body>',
+        json: '{"test": "json"}'
+      },
+      {
+        fixture: './test/fixtures/some-data.json',
+        filePath: './test/fixtures/some-data.csv',
+        html: '<body></body>',
+        json: '{"test": "json"}',
+        text: 'test text'
+      }
+    ];
+
+    optionSets.forEach(optionSet => {
+      expect(() => {
+        mockyeah.get('/service/end/point', optionSet);
+      }).to.throw('Response options must not include more than one of the following: ' + payloadKeys.join(', '));
+    });
+  });
+
   describe('Status', () => {
     it('should return 404 for undeclared services', (done) => {
       request


### PR DESCRIPTION
We only want the user to be able to send one response type at a time. With these
restrictions, we can assert that there is only one of the response prop types we
intend the user to have the the response object, at a time.