### PR TITLE
Allow verbose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+before_script:
+  - npm install -g gulp
+script:
+  - gulp lint
+  - gulp test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mock Yeah
+# Mock Yeah [![Build Status](https://travis-ci.org/ryanricard/mock-yeah.svg)](https://travis-ci.org/ryanricard/mock-yeah)
 
 __"An invaluable service mocking platform built on Express."__
 

--- a/config.js
+++ b/config.js
@@ -16,7 +16,8 @@ config.file({
 })
 .defaults({
   port: 4001,
-  fixturesDir: './fixtures'
+  fixturesDir: './fixtures',
+  accessControlAllowOrigin: false
 });
 
 module.exports = config;

--- a/config.js
+++ b/config.js
@@ -17,7 +17,8 @@ config.file({
 .defaults({
   port: 4001,
   fixturesDir: './fixtures',
-  accessControlAllowOrigin: false
+  accessControlAllowOrigin: false,
+  verbose: false
 });
 
 module.exports = config;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const httpServer = app.listen(app.config.get('port'), function listen() {
   const host = this.address().address;
   const port = this.address().port;
 
-  console.log('Mock Yeah listening at http://%s:%s', host, port);
+  console.log(`Mock Yeah listening at http://${host}:${port}`);
 });
 
 module.exports = app.RouteManager;

--- a/index.js
+++ b/index.js
@@ -2,12 +2,15 @@
 /* eslint-disable no-console */
 
 const app = require('./server').app;
-
+const middleware = require('./server/middleware');
 app.config = require('./config');
 
 if (app.config.get('accessControlAllowOrigin')) {
-  const accessControlAllowOrigin = require('./server/middleware').accessControlAllowOrigin;
-  app.use(accessControlAllowOrigin);
+  app.use(middleware.accessControlAllowOrigin);
+}
+
+if (app.config.get('verbose')) {
+  app.use(middleware.logRequest);
 }
 
 const httpServer = app.listen(app.config.get('port'), function listen() {

--- a/index.js
+++ b/index.js
@@ -5,6 +5,11 @@ const app = require('./server').app;
 
 app.config = require('./config');
 
+if (app.config.get('accessControlAllowOrigin')) {
+  const accessControlAllowOrigin = require('./server/middleware').accessControlAllowOrigin;
+  app.use(accessControlAllowOrigin);
+}
+
 const httpServer = app.listen(app.config.get('port'), function listen() {
   const host = this.address().address;
   const port = this.address().port;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-yeah",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "An invaluable service mocking platform built on Express.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-yeah",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An invaluable service mocking platform built on Express.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-yeah",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "description": "An invaluable service mocking platform built on Express.",
   "main": "index.js",
   "scripts": {

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -6,3 +6,8 @@ exports.accessControlAllowOrigin = function allowCrossDomain(req, res, next) {
   res.header('Access-Control-Allow-Headers', 'Content-Type');
   next();
 };
+
+exports.logRequest = function logRequest(req, res, next) {
+  console.log(`${req.method} ${req.url}`);
+  next();
+};

--- a/server/middleware/index.js
+++ b/server/middleware/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+exports.accessControlAllowOrigin = function allowCrossDomain(req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  next();
+};


### PR DESCRIPTION
This can be useful for debugging your requests when running through test runners.
It allows you to verify that the correct calls are being made in the right places,
this will most likely serve as a sanity check, but it has been useful in the past.

**Note**: *Depends on https://github.com/ryanricard/mock-yeah/commit/3ed9635230b2b1ff16adf9cead0801a5a5bccb06*