### PR TITLE
Add Express Middleware for CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "cors": "^2.7.1",
     "express": "^4.13.3",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@
 
 const App = require('../app');
 const prepareConfig = require('../lib/prepareConfig');
+const cors = require('cors');
 /**
  * Server module
  * @param  {Object} config Application configuration.
@@ -12,6 +13,9 @@ module.exports = function Server(config) {
 
   // Instantiate an application
   const app = new App(config);
+
+  // Enable CORS for all routes
+  app.use(cors());
 
   // Start server on conigured hose and port
   const server = app.listen(config.port, config.host, function listen() {


### PR DESCRIPTION
[cors](https://github.com/expressjs/cors) is an expressjs made middleware, for enabling CORS with various options.

Since we're using proxies for real services to record fixtures, if we want to be able to use those same endpoints while developing, we'll need to be able to allow users to have CORS enabled for all routes.