### PR TITLE
Trap invalid .mockyeah config

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,7 +9,6 @@ let config;
 
 try {
   config = fs.readFileSync(path.resolve(relativeRoot, '.mockyeah'));
-  config = JSON.parse(config);
 } catch (err) {
   // noop
 }
@@ -18,10 +17,15 @@ try {
 try {
   if (!config) {
     config = fs.readFileSync(path.resolve(relativeRoot, '.mock-yeah'));
-    config = JSON.parse(config);
   }
 } catch (err) {
   // noop
+}
+
+try {
+  if (config) config = JSON.parse(config);
+} catch (err) {
+  throw new Error('.mockyeah configuration file JSON invalid.');
 }
 
 module.exports = prepareConfig(config);

--- a/config.js
+++ b/config.js
@@ -25,7 +25,7 @@ try {
 try {
   if (config) config = JSON.parse(config);
 } catch (err) {
-  throw new Error('.mockyeah configuration file JSON invalid.');
+  throw new Error('Invalid JSON in .mockyeah configuration file');
 }
 
 module.exports = prepareConfig(config);


### PR DESCRIPTION
Trap parsing of invalid .mockyeah configuration and throw useful error.

I manually tested with `test/dummy`... I have not yet figured out a way to write an automated test.