### PR TITLE
Validate Response Object

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -14,15 +14,31 @@ function RouteResolver(app) {
 }
 
 function validateResponse(response) {
-  const payloadKeysPresent = [];
-  const payloadKeys = ['fixture', 'filePath', 'html', 'json', 'text'];
+  let payloadKeysPresent = 0;
+  const payloadKeys = Object.keys(response);
+  const expectedPayloadKeys = [
+    'fixture',
+    'filePath',
+    'html',
+    'json',
+    'text',
+    'status',
+    'headers',
+    'raw',
+    'latency',
+    'type'
+  ];
 
   payloadKeys.forEach(key => {
-    if (response[key]) payloadKeysPresent.push(response[key]);
+    expectedPayloadKeys.forEach(expectedKey => { if (key === expectedKey) ++payloadKeysPresent; });
   });
 
   if (payloadKeysPresent.length > 1) {
-    throw new Error('Response options must not include more than one of the following: ' + payloadKeys.join(', '));
+    throw new Error(`Response options must not include more than one of the following: ${expectedPayloadKeys.join(', ')}`);
+  }
+
+  if (payloadKeys.length !== payloadKeysPresent) {
+    throw new Error(`Response option(s) invalid. Options must include one of the following: ${expectedPayloadKeys.join(', ')}`);
   }
 }
 

--- a/test/integration/ResponseValidationTest.js
+++ b/test/integration/ResponseValidationTest.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const TestHelper = require('../TestHelper');
+const mockyeah = TestHelper.mockyeah;
+const request = TestHelper.request;
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Response Validation', () => {
+  it('should validate response option(s) are correct', done => {
+    try {
+      // Use incorrect option 'file'
+      mockyeah.get('/some/service/end/point', { file: './fixtures/some-data.json' });
+    } catch (err) {
+      expect(err.message).to.equal('Response option(s) invalid. Options must include one of the following: fixture, filePath, html, json, text, status, headers, raw, latency, type');
+      done();
+    }
+
+    request
+      .get('/some/service/end/point')
+      .expect(404);
+  });
+});


### PR DESCRIPTION
When users are beginning to use the api, or forget the correct options
to pass, there was no clear indication to the user that they were doing
so. This resulted in mockyeah still sending `200`s and just showing a
blank response.

We should be able to inform the user that they did not correctly pass
the right options, and subsequently break execution.
________________________
closes https://github.com/ryanricard/mockyeah/issues/17