### PR TITLE
Add mock expectation support

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('express');
+const bodyParser = require('body-parser');
 const Logger = require('./lib/Logger');
 const RouteManager = require('./lib/RouteManager');
 
@@ -29,6 +30,8 @@ module.exports = function App(config) {
 
   // Attach RouteManager to app object, the primary set of mockyeah API methods.
   app.routeManager = new RouteManager(app);
+
+  app.use(bodyParser.json());
 
   app.get('/', (req, res) => {
     res.send('Hello, mockyeah!');

--- a/app/lib/Expectation.js
+++ b/app/lib/Expectation.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const assert = require('assert');
+
+/**
+ * Expectation
+ *  Provides mock service assertion api
+ */
+function Expectation(route) {
+  this.route = route;
+  this.prefix = `[${this.route.method}] ${this.route.path} --`;
+  this.called = 0;
+  this.assertions = [];
+  this.handlers = [];
+  return this;
+}
+
+Expectation.prototype.middleware = function middleware(req, res, next) {
+  this.called += 1;
+  this.handlers.forEach((handler) => {
+    this.assertions.push(handler.bind(this, req));
+  });
+  next();
+};
+
+Expectation.prototype.api = function api() {
+  const internal = this;
+  return {
+    atLeast: function atLeast(number) {
+      internal.assertions.push(() => {
+        assert(internal.called >= number, `${internal.prefix} Expected route to be called at least ${number} times, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    atMost: function atMost(number) {
+      internal.assertions.push(() => {
+        assert(internal.called <= number, `${internal.prefix} Expected route to be called at most ${number} times, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    never: function never() {
+      internal.assertions.push(() => {
+        assert(internal.called === 0, `${internal.prefix} Expected route to be called never, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    once: function once() {
+      internal.assertions.push(() => {
+        assert(internal.called === 1, `${internal.prefix} Expected route to be called once, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    twice: function twice() {
+      internal.assertions.push(() => {
+        assert(internal.called === 2, `${internal.prefix} Expected route to be called twice, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    thrice: function thrice() {
+      internal.assertions.push(() => {
+        assert(internal.called === 3, `${internal.prefix} Expected route to be called thrice, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    exactly: function exactly(number) {
+      internal.assertions.push(() => {
+        assert(internal.called === number, `${internal.prefix} Expected route to be called ${number} times, but it was called ${internal.called} times`);
+      });
+      return this;
+    },
+    header: function header(name, value) {
+      internal.handlers.push((req) => {
+        const actualValue = req.get(name);
+        assert.equal(req.get(name), value, `${internal.prefix} Expected header value ${name}:${value}, but it was ${actualValue}`);
+      });
+      return this;
+    },
+    params: function params(value) {
+      internal.handlers.push((req) => {
+        assert.deepStrictEqual(req.query, value, `${internal.prefix} Expected params did not match expected for request`);
+      });
+      return this;
+    },
+    body: function body(value) {
+      internal.handlers.push((req) => {
+        assert.deepStrictEqual(req.body, value, `${internal.prefix} Expected body to match expected for request`);
+      });
+      return this;
+    },
+    verify: function verify() {
+      internal.assertions.forEach((assertion) => assertion());
+    }
+  };
+};
+
+module.exports = Expectation;

--- a/app/lib/Expectation.js
+++ b/app/lib/Expectation.js
@@ -71,7 +71,7 @@ Expectation.prototype.api = function api() {
     header: function header(name, value) {
       internal.handlers.push((req) => {
         const actualValue = req.get(name);
-        assert.equal(req.get(name), value, `${internal.prefix} Expected header value ${name}:${value}, but it was ${actualValue}`);
+        assert.equal(actualValue, value, `${internal.prefix} Expected header value ${name}:${value}, but it was ${actualValue}`);
       });
       return this;
     },

--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -14,27 +14,27 @@ module.exports = function RouteManager(app) {
 
   return {
     register: function register(method, _path, response) {
-      routeStore.register(method, _path, response);
+      return routeStore.register(method, _path, response);
     },
 
     all: function all(_path, response) {
-      this.register('all', _path, response);
+      return this.register('all', _path, response);
     },
 
     get: function get(_path, response) {
-      this.register('get', _path, response);
+      return this.register('get', _path, response);
     },
 
     post: function post(_path, response) {
-      this.register('post', _path, response);
+      return this.register('post', _path, response);
     },
 
     put: function put(_path, response) {
-      this.register('put', _path, response);
+      return this.register('put', _path, response);
     },
 
     delete: function _delete(_path, response) {
-      this.register('delete', _path, response);
+      return this.register('delete', _path, response);
     },
 
     reset: function reset() {

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
 const expandPath = require('../../lib/expandPath');
-
+const Expectation = require('./Expectation');
 /**
  * RouteResolver
  *  Facilitates route registration and unregistration.
@@ -106,10 +106,16 @@ RouteResolver.prototype.register = function register(route) {
     route.response = handler.call(this, route.response);
   }
 
+  const expectation = new Expectation(route);
+
   // unregister existing matching routes
   this.unregister([route]);
 
-  this.app[route.method](route.path, route.response);
+  this.app[route.method](route.path, expectation.middleware.bind(expectation), route.response);
+
+  return {
+    expect: () => expectation.api()
+  };
 };
 
 RouteResolver.prototype.unregister = function unregister(routes) {

--- a/app/lib/RouteStore.js
+++ b/app/lib/RouteStore.js
@@ -15,8 +15,8 @@ function RouteStore(app) {
 
 RouteStore.prototype.register = function register(method, path, response) {
   const route = { method, path, response };
-  this.routeResolver.register(route);
   this.routes.push(route);
+  return this.routeResolver.register(route);
 };
 
 RouteStore.prototype.reset = function reset() {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "body-parser": "^1.15.2",
     "cors": "^2.7.1",
     "express": "^4.13.3",
     "lodash": "^3.10.1",

--- a/test/integration/RouteExpectationTest.js
+++ b/test/integration/RouteExpectationTest.js
@@ -1,0 +1,290 @@
+'use strict';
+
+const TestHelper = require('../TestHelper');
+const MockYeahServer = require('../../server');
+const supertest = require('supertest');
+const async = require('async');
+const expect = require('chai').expect;
+
+describe('Route expectation', () => {
+  let mockyeah;
+  let request;
+
+  before(() => {
+    mockyeah = MockYeahServer({ port: 0 });
+    request = supertest(mockyeah.server);
+  });
+
+  after(() => mockyeah.close());
+
+  it('should implement never() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .never();
+
+    async.series([
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called never, but it was called 1 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement once() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .once();
+
+    async.series([
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called once, but it was called 0 times');
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called once, but it was called 2 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement twice() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .twice();
+
+    async.series([
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called twice, but it was called 1 times');
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called twice, but it was called 3 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement thrice() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .thrice();
+
+    async.series([
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called thrice, but it was called 2 times');
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called thrice, but it was called 4 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement exactly() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .exactly(7);
+
+    async.series([
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called 7 times, but it was called 6 times');
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called 7 times, but it was called 8 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement atMost() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .atMost(3);
+
+    async.series([
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called at most 3 times, but it was called 4 times');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement atLeast() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .atLeast(3);
+
+    async.series([
+      (cb) => request.get('/foo').end(cb),
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected route to be called at least 3 times, but it was called 2 times');
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement params() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .params({
+        id: '9999'
+      });
+
+    async.series([
+      (cb) => request.get('/foo?id=9999').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected params did not match expected for request');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement body() expectation', (done) => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .body({
+        foo: 'bar'
+      });
+
+    async.series([
+      (cb) => request.post('/foo').send({ foo: 'bar' }).end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.post('/foo').send({ some: 'value' }).end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected body to match expected for request');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should implement header() expectation', (done) => {
+    const expectation = mockyeah
+      .get('/foo', { text: 'bar' })
+      .expect()
+      .header('host', 'example.com');
+
+    async.series([
+      (cb) => request.get('/foo').set('HOST', 'example.com').end(cb),
+      (cb) => {
+        expectation.verify();
+        cb();
+      },
+      (cb) => request.get('/foo').set('HOST', 'unknown.com').end(cb),
+      (cb) => {
+        expect(expectation.verify).to.throw('Expected header value host:example.com, but it was unknown.com');
+        cb();
+      }
+    ], done);
+  });
+
+  it('should allow composable expectations', (done) => {
+    const expectation = mockyeah
+      .post('/foo', { text: 'bar' })
+      .expect()
+      .header('host', 'example.com')
+      .params({
+        id: '9999'
+      })
+      .body({
+        foo: 'bar'
+      })
+      .once();
+
+    request
+      .post('/foo?id=9999')
+      .set('HOST', 'example.com')
+      .send({ foo: 'bar' })
+      .end(() => {
+        expectation.verify();
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Initial implementation of adding expectation interface to all api methods. 

Example:

```js
const expectation = mockyeah
  .post('/foo', { text: 'bar' })
  .expect()
  .header('host', 'example.com')
  .params({
    id: '9999'
  })
  .body({
    foo: 'bar'
  })
  .once();

request
  .post('/foo?id=9999')
  .set('HOST', 'example.com')
  .send({ foo: 'bar' })
  .end(() => {
    expectation.verify();
    done();
  });
```