### PR TITLE
Add output control configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ __Default `.mockyeah` configuration:__
   "host": "localhost",
   "port": 4001,
   "fixturesDir": "./fixtures",
-  "capturesDir": "./mockyeah"
+  "capturesDir": "./mockyeah",
+  "output": true,
+  "verbose": false
 }
 ```
 __Configuration options:__
@@ -151,6 +153,8 @@ __Configuration options:__
 - `port`: Port on which mockyeah will run.
 - `fixturesDir`: Relative path to the fixtures directory.
 - `capturesDir`: Relative path to the captures directory.
+- `output`: Boolean to toggle mockyeah generated output written to stdout.
+- `verbose`: Boolean to toggle verbosity of mockyeah generated output.
 
 Overriding any of these configurations can be done by placing a `.mockyeah`
 file in root of the project and adding the key value pair that needs to be updated.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ __Default `.mockyeah` configuration:__
   "fixturesDir": "./fixtures",
   "capturesDir": "./mockyeah",
   "output": true,
+  "journal": false,
   "verbose": false
 }
 ```
@@ -154,6 +155,25 @@ __Configuration options:__
 - `fixturesDir`: Relative path to the fixtures directory.
 - `capturesDir`: Relative path to the captures directory.
 - `output`: Boolean to toggle mockyeah generated output written to stdout.
+- `journal`: Boolean to toggle request journaling. Example:
+```
+[mockyeah][14:54:21][REQUEST][JOURNAL] {
+  "callCount": 1,
+  "url": "/foo?bar=baa",
+  "fullUrl": "http://localhost:4001/foo?bar=baa",
+  "clientIp": "127.0.0.1",
+  "method": "GET",
+  "headers": {
+    "host": "localhost:4001",
+    "user-agent": "curl/7.43.0",
+    "accept": "*/*"
+  },
+  "query": {
+    "bar": "baa"
+  },
+  "body": {}
+}
+```
 - `verbose`: Boolean to toggle verbosity of mockyeah generated output.
 
 Overriding any of these configurations can be done by placing a `.mockyeah`

--- a/app/index.js
+++ b/app/index.js
@@ -16,6 +16,7 @@ module.exports = function App(config) {
   const defaultConfig = {
     name: 'mockyeah',
     output: true,
+    journal: false,
     verbose: false
   };
 

--- a/app/index.js
+++ b/app/index.js
@@ -14,15 +14,24 @@ module.exports = function App(config) {
   const app = express();
 
   const defaultConfig = {
-    name: 'mockyeah'
+    name: 'mockyeah',
+    output: true,
+    verbose: false
   };
 
-  // Prepare configuration. Merge configuration with default configuration
-  app.config = Object.assign({}, defaultConfig, config || {});
+  // Prepare global config
+  const globalConfig = {};
+  if (global.MOCKYEAH_SUPPRESS_OUTPUT !== undefined) globalConfig.output = !global.MOCKYEAH_SUPPRESS_OUTPUT;
+  if (global.MOCKYEAH_VERBOSE_OUTPUT !== undefined) globalConfig.verbose = !!global.MOCKYEAH_VERBOSE_OUTPUT;
+
+  // Prepare configuration. Merge configuration with global and default configuration
+  app.config = Object.assign({}, defaultConfig, globalConfig, config || {});
 
   // Instantiate new logger
   const logger = new Logger({
-    name: app.config.name
+    name: app.config.name,
+    output: app.config.output,
+    verbose: app.config.verbose
   });
 
   // Attach log to app instance to bind output to app instance

--- a/app/index.js
+++ b/app/index.js
@@ -38,6 +38,9 @@ module.exports = function App(config) {
   // Attach log to app instance to bind output to app instance
   app.log = logger.log.bind(logger);
 
+  // Provide user feedback when verbose output is enabled
+  app.log('info', 'verbose output enabled', true);
+
   // Attach RouteManager to app object, the primary set of mockyeah API methods.
   app.routeManager = new RouteManager(app);
 

--- a/app/lib/Expectation.js
+++ b/app/lib/Expectation.js
@@ -20,6 +20,7 @@ Expectation.prototype.middleware = function middleware(req, res, next) {
   this.handlers.forEach((handler) => {
     this.assertions.push(handler.bind(this, req));
   });
+  req.callCount = this.called;
   next();
 };
 

--- a/app/lib/Logger.js
+++ b/app/lib/Logger.js
@@ -10,8 +10,8 @@ const Logger = function Logger(options) {
   options = options || {};
 
   this.name = options.name;
-  this.suppress = global.MOCKYEAH_SUPPRESS_OUTPUT !== undefined ? global.MOCKYEAH_SUPPRESS_OUTPUT : false;
-  this.verbose = global.MOCKYEAH_VERBOSE_OUTPUT !== undefined ? global.MOCKYEAH_VERBOSE_OUTPUT : false;
+  this.output = options.output;
+  this.verbose = options.verbose;
 
   return this;
 };
@@ -59,8 +59,8 @@ function prepareArguments(/* [type=INFO], message, [verbose=true] */) {
 Logger.prototype.log = function log(/* [type=INFO], message, [verbose=true] */) {
   const args = prepareArguments.apply(this, arguments);
 
-  // If suppressing output, abort
-  if (this.suppress) return;
+  // If silencing output, abort
+  if (!this.output) return;
 
   // If verbose is off and message is flagged as verbose output, abort
   if (!this.verbose && args.verbose) return;

--- a/app/lib/Logger.js
+++ b/app/lib/Logger.js
@@ -68,6 +68,12 @@ Logger.prototype.log = function log(/* [type=INFO], message, [verbose=true] */) 
   // If message is specified to not display when outputing verbose
   if (this.verbose && !args.always && !args.verbose) return;
 
+  // Explicity indicate verbose messages
+  if (args.verbose) args.types.unshift('verbose');
+
+  // Add timestamp to message
+  args.types.unshift((new Date()).toLocaleTimeString('en-US', { hour12: false }));
+
   // Prepare string of types for output
   args.types = args.types.reduce((result, value) => {
     return `${result}[${value.toUpperCase()}]`;

--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -14,6 +14,7 @@ module.exports = function RouteManager(app) {
 
   return {
     register: function register(method, _path, response) {
+      app.log(['serve', 'mount', method], _path);
       return routeStore.register(method, _path, response);
     },
 
@@ -52,8 +53,8 @@ module.exports = function RouteManager(app) {
       app.log(['serve', 'capture'], tildify(capture.path));
 
       capture.files().forEach((route) => {
-        app.log(['serve', 'mount', route.method], route.originalPath, false);
-        app.log(['serve', 'mount', route.method], `${route.originalPath} at ${route.path}`, true);
+        app.log(['serve', 'playing', route.method], route.originalPath, false);
+        app.log(['serve', 'playing', route.method], `${route.originalPath} at ${route.path}`, true);
 
         this.register(route.method, route.path, route.options);
       });

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -58,6 +58,20 @@ function handler(response) {
     const start = (new Date).getTime();
     let send;
 
+    if (this.app.config.journal) {
+      this.app.log(['request', 'journal'], JSON.stringify({
+        callCount: req.callCount,
+        url: req.url,
+        fullUrl: req.protocol + '://' + req.get('host') + req.originalUrl,
+        clientIp: req.headers['x-forwarded-for'] || req.connection.remoteAddress,
+        method: req.method,
+        headers: req.headers,
+        query: req.query,
+        body: req.body,
+        cookies: req.cookies
+      }, null, 2));
+    }
+
     // Default latency to 0 when undefined
     response.latency = response.latency || 0;
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ const cors = require('cors');
  * @param  {Object} config Application configuration.
  * @return {Instances} Instance of a http server.
  */
-module.exports = function Server(config) {
+module.exports = function Server(config, onStart) {
   config = prepareConfig(config);
 
   // Instantiate an application
@@ -20,6 +20,8 @@ module.exports = function Server(config) {
   // Start server on conigured hose and port
   const server = app.listen(config.port, config.host, function listen() {
     app.log('serve', `Listening at http://${this.address().address}:${this.address().port}`);
+    // Execute callback once server starts
+    if (onStart) onStart.call(null);
   });
 
   // Expose ability to stop server via API

--- a/test/integration/ConfigTest.js
+++ b/test/integration/ConfigTest.js
@@ -31,6 +31,51 @@ describe('Config', () => {
     });
   });
 
+  it('should not write verbose output to stdout by default', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      const mockyeah = new require('./server')({ port: 0 });
+      mockyeah.get('/foo', { text: 'bar' });
+      request(mockyeah.server)
+      .get('/foo?bar=true')
+      .expect(200, /bar/, process.exit);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.not.include('verbose output enabled');
+      done();
+    });
+  });
+
+  it('should  write verbose output to stdout when enabled', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      const mockyeah = new require('./server')({ port: 0, verbose: true });
+      mockyeah.get('/foo', { text: 'bar' });
+      request(mockyeah.server)
+      .get('/foo?bar=true')
+      .expect(200, /bar/, process.exit);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.include('verbose output enabled');
+      done();
+    });
+  });
+
+  it('should not write verbose output to stdout when disabled', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      // const mockyeah = new require('./server')({ port: 0, verbose: false });
+      const mockyeah = require('./index');
+      setTimeout(function() {
+        mockyeah.get('/foo', { text: 'bar' });
+        request(mockyeah.server)
+        .get('/foo?bar=true')
+        .expect(200, /bar/, process.exit);
+      }, 1000);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.not.include('verbose output enabled');
+      done();
+    });
+  });
+
   it('should not write journaled output to stdout by default', function(done) {
     exec(`echo "
       const request = require('supertest');

--- a/test/integration/ConfigTest.js
+++ b/test/integration/ConfigTest.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const exec = require('child_process').exec;
+const expect = require('chai').expect;
+
+describe('Config', () => {
+  it('should write output to stdout by default', function(done) {
+    exec(`echo "
+      const mockyeah = new require('./server')({ port: 0 }, function() { process.exit() });
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.include('mockyeah');
+      done();
+    });
+  });
+
+  it('should write output to stdout when enabled', function(done) {
+    exec(`echo "
+      const mockyeah = new require('./server')({ port: 0, output: true }, function() { process.exit() });
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.include('mockyeah');
+      done();
+    });
+  });
+
+  it('should not write to stdout when disabled', function(done) {
+    exec(`echo "
+      const mockyeah = new require('./server')({ port: 0, output: false }, function() { process.exit() });
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.not.include('mockyeah');
+      done();
+    });
+  });
+});

--- a/test/integration/ConfigTest.js
+++ b/test/integration/ConfigTest.js
@@ -30,4 +30,46 @@ describe('Config', () => {
       done();
     });
   });
+
+  it('should not write journaled output to stdout by default', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      const mockyeah = new require('./server')({ port: 0 });
+      mockyeah.get('/foo', { text: 'bar' });
+      request(mockyeah.server)
+        .get('/foo?bar=true')
+        .expect(200, /bar/, process.exit);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.not.include('JOURNAL');
+      done();
+    });
+  });
+
+  it('should write journaled output to stdout when enabled', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      const mockyeah = new require('./server')({ port: 0, journal: true });
+      mockyeah.get('/foo', { text: 'bar' });
+      request(mockyeah.server)
+        .get('/foo?bar=true')
+        .expect(200, /bar/, process.exit);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.include('JOURNAL');
+      done();
+    });
+  });
+
+  it('should not write journaled output to stdout when disabled ', function(done) {
+    exec(`echo "
+      const request = require('supertest');
+      const mockyeah = new require('./server')({ port: 0, journal: false });
+      mockyeah.get('/foo', { text: 'bar' });
+      request(mockyeah.server)
+        .get('/foo?bar=true')
+        .expect(200, /bar/, process.exit);
+      " | node`, function(err, stdout, stderr) {
+      expect(stdout).to.not.include('JOURNAL');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
- Adds request journaling
- Adds ability to control mockyeah generated output, journaling, and verbosity via configuration. 
- Adds `[verbose]` output indicator
- Adds `onStart` callback to server module.

Resolves #28 
Also related to #34 