### PR TITLE
RouteResolver#unregister should also test if route method matches

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -133,10 +133,10 @@ RouteResolver.prototype.register = function register(route) {
 };
 
 RouteResolver.prototype.unregister = function unregister(routes) {
-  const routePaths = routes.map((route) => { return route.path; });
-
   this.app._router.stack = this.app._router.stack.filter((layer) => {
-    return !(layer.route && routePaths.indexOf(layer.route.path) >= 0);
+    return !(layer.route && routes.some((route) => {
+      return route.path === layer.route.path && layer.route.methods[route.method] === true;
+    }));
   });
 };
 


### PR DESCRIPTION
This change lets to mock responses for the same endpoint but with different HTTP methods, 
eg.

```js
srv.delete('/rules', {status: 204});
srv.post('/rules', {status: 201}); //before this change, this line will unregister mock for delete method
```