### PR TITLE
feat: ignore query/search parameters in paths

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const parse = require('url').parse;
 const _ = require('lodash');
 const expandPath = require('../../lib/expandPath');
 const Expectation = require('./Expectation');
@@ -120,12 +121,14 @@ RouteResolver.prototype.register = function register(route) {
     route.response = handler.call(this, route.response);
   }
 
+  route.pathname = parse(route.path, true).pathname;
+
   const expectation = new Expectation(route);
 
   // unregister existing matching routes
   this.unregister([route]);
 
-  this.app[route.method](route.path, expectation.middleware.bind(expectation), route.response);
+  this.app[route.method](route.pathname, expectation.middleware.bind(expectation), route.response);
 
   return {
     expect: () => expectation.api()
@@ -135,7 +138,7 @@ RouteResolver.prototype.register = function register(route) {
 RouteResolver.prototype.unregister = function unregister(routes) {
   this.app._router.stack = this.app._router.stack.filter((layer) => {
     return !(layer.route && routes.some((route) => {
-      return route.path === layer.route.path && layer.route.methods[route.method] === true;
+      return route.pathname === layer.route.path && layer.route.methods[route.method] === true;
     }));
   });
 };

--- a/test/integration/RouteRegisterTest.js
+++ b/test/integration/RouteRegisterTest.js
@@ -45,4 +45,20 @@ describe('Route register', () => {
       (cb) => request.delete('/foo').expect(200, 'bar delete', cb)
     ], done);
   });
+
+  it('should work even with query/search parameters', (done) => {
+    mockyeah.get('/foo?ok=yes', { text: 'bar', status: 200 });
+
+    request
+      .get('/foo')
+      .query({ ok: 'yes', other: 'sure' })
+      .expect(200, 'bar', () => {
+        mockyeah.get('/foo?ok', { text: 'baa', status: 301 });
+
+        request
+          .get('/foo')
+          .query({ ok: '', other: 'why not' })
+          .expect(301, 'baa', done);
+      });
+  });
 });


### PR DESCRIPTION
`mockyeah`, in some of my testing, seems to have slightly unintuitive behavior when paths are defined with query parameters. Methods can be declared with parameters without error, but requesting against them with and without those parameters can both fail with an HTTP 404 response. Perhaps express is escaping/encoding the question mark before setting up the route.

This changes the behavior to strip the query parameters before setting up the route path. It may seem like a trivial or useless change, but it starts a foundation for future work to actually support query parameters in route matching, with this inline string syntax, as well as an extended one that supports optional parameters, multiple possible values, etc.
