### PR TITLE
refactor: use generic route handler with matching

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -41,14 +41,14 @@ module.exports = function App(config) {
   // Provide user feedback when verbose output is enabled
   app.log('info', 'verbose output enabled', true);
 
-  // Attach RouteManager to app object, the primary set of mockyeah API methods.
-  app.routeManager = new RouteManager(app);
-
-  app.use(bodyParser.json());
-
   app.get('/', (req, res) => {
     res.send('Hello, mockyeah!');
   });
+
+  app.use(bodyParser.json());
+
+  // Attach RouteManager to app object, the primary set of mockyeah API methods.
+  app.routeManager = new RouteManager(app);
 
   return app;
 };

--- a/app/lib/RouteManager.js
+++ b/app/lib/RouteManager.js
@@ -45,7 +45,7 @@ module.exports = function RouteManager(app) {
 
     record: function record(captureName) {
       const capture = new CaptureRecorder(app, captureName);
-      this.register('all', '*', capture.record.bind(capture));
+      app.use(capture.record.bind(capture));
     },
 
     play: function play(captureName) {

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -2,9 +2,38 @@
 
 const fs = require('fs');
 const path = require('path');
+const parse = require('url').parse;
 const _ = require('lodash');
+const pathToRegExp = require('path-to-regexp');
 const expandPath = require('../../lib/expandPath');
 const Expectation = require('./Expectation');
+
+function isEqualMethod(method1, method2) {
+  const m1 = method1.toLowerCase();
+  const m2 = method2.toLowerCase();
+  return m1 === 'all' || m2 === 'all' || m1 === m2;
+}
+
+function isRouteForRequest(route, req) {
+  if (!isEqualMethod(req.method, route.method)) return false;
+
+  const pathname = parse(req.url, true).pathname;
+
+  if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;
+
+  // TODO: Later add features to match other things, like query parameters, etc.
+
+  return true;
+}
+
+function isRouteToReplace(newRoute, oldRoute) {
+  if (newRoute.pathname === oldRoute.pathname && newRoute.method === oldRoute.method) {
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * RouteResolver
  *  Facilitates route registration and unregistration.
@@ -12,6 +41,10 @@ const Expectation = require('./Expectation');
  */
 function RouteResolver(app) {
   this.app = app;
+
+  this.routes = [];
+
+  this.listening = false;
 }
 
 function validateResponse(response) {
@@ -120,12 +153,18 @@ RouteResolver.prototype.register = function register(route) {
     route.response = handler.call(this, route.response);
   }
 
+  route.pathname = parse(route.path, true).pathname;
+  route.pathRegExp = pathToRegExp(route.pathname);
+
   const expectation = new Expectation(route);
+  route.expectation = expectation;
 
   // unregister existing matching routes
   this.unregister([route]);
 
-  this.app[route.method](route.path, expectation.middleware.bind(expectation), route.response);
+  this.routes.push(route);
+
+  this.listen();
 
   return {
     expect: () => expectation.api()
@@ -133,10 +172,35 @@ RouteResolver.prototype.register = function register(route) {
 };
 
 RouteResolver.prototype.unregister = function unregister(routes) {
-  this.app._router.stack = this.app._router.stack.filter((layer) => {
-    return !(layer.route && routes.some((route) => {
-      return route.path === layer.route.path && layer.route.methods[route.method] === true;
-    }));
+  // Filter out any old routes that match any of the new routes being unregistered.
+  this.routes = this.routes.filter(oldRoute =>
+    !routes.some(newRoute => isRouteToReplace(newRoute, oldRoute))
+  );
+};
+
+RouteResolver.prototype.listen = function listen() {
+  if (this.listening) return;
+
+  this.listening = true;
+
+  this.app.all('*', (req, res, next) => {
+    const route = this.routes.find(r => isRouteForRequest(r, req));
+
+    if (!route) {
+      next();
+      return;
+    }
+
+    const expectationNext = err => {
+      if (err) {
+        this.app.log(['record', 'expectation', 'error'], err);
+        res.sendStatus(500);
+        return;
+      }
+      route.response(req, res);
+    };
+
+    route.expectation.middleware(req, res, expectationNext);
   });
 };
 

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -27,11 +27,7 @@ function isRouteForRequest(route, req) {
 }
 
 function isRouteToReplace(newRoute, oldRoute) {
-  if (newRoute.pathname === oldRoute.pathname && newRoute.method === oldRoute.method) {
-    return true;
-  }
-
-  return false;
+  return newRoute.pathname === oldRoute.pathname && newRoute.method === oldRoute.method;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "express": "^4.13.3",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
+    "path-to-regexp": "^2.1.0",
     "request": "^2.69.0",
     "tildify": "^1.1.2"
   }

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const TestHelper = require('../TestHelper');
+const mockyeah = TestHelper.mockyeah;
+const request = TestHelper.request;
+
+describe('Route Patterns', () => {
+  it('should work with route parameter', (done) => {
+    mockyeah.get('/service/:key');
+
+    request
+      .get('/service/exists')
+      .expect(200, done);
+  });
+
+  it('should work with regular expression slash any count', (done) => {
+    mockyeah.get('/service/(.{0,})');
+
+    request
+      .get('/service/exists')
+      .expect(200, done);
+  });
+
+  it('should work with regular expression slash any star', (done) => {
+    mockyeah.get('/(.*)');
+
+    request
+      .get('/service/exists')
+      .expect(200, done);
+  });
+
+  it('should work with regular expression any star', (done) => {
+    mockyeah.get('(.*)');
+
+    request
+      .get('/service/exists')
+      .expect(200, done);
+  });
+
+  it('should work with star', (done) => {
+    mockyeah.get('*');
+
+    request
+      .get('/service/exists')
+      .expect(200, done);
+  });
+});


### PR DESCRIPTION
This refactors `mockyeah` to use a generic route handler (`app.all('*', ...)`), and match against mocked routes within that handler. This will enable future work to support matching on things other than path, such as query parameters, headers, body, etc., similar to `nock` (here https://github.com/ryanricard/mockyeah/pull/46/files#diff-0b172c7ee81949d36b184c92f0aa5baeR24).

All existing tests pass, unmodified, and new tests were added now that we support full Express route patterns. That means we still support unregistering routes, etc.

Closes https://github.com/ryanricard/mockyeah/pull/44.