### PR TITLE
fix: restore request params for custom middleware

### DIFF
--- a/app/lib/routeHandler.js
+++ b/app/lib/routeHandler.js
@@ -49,8 +49,8 @@ function verifyFile(filePath, message) {
   });
 }
 
-module.exports = function handler(response) {
-  response = response || {};
+module.exports = function handler(route) {
+  const response = route.response || {};
 
   validateResponse(response);
 

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -36,7 +36,7 @@ describe('Route Patterns', () => {
     });
   });
 
-  it.only('should expose path parameters to custom middleware as indexed array', done => {
+  it('should expose path parameters to custom middleware as indexed array', done => {
     let report = true;
     mockyeah.get('/service/:one/:two/other/:three', (req, res) => {
       try {

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -3,12 +3,54 @@
 const TestHelper = require('../TestHelper');
 const mockyeah = TestHelper.mockyeah;
 const request = TestHelper.request;
+const expect = require('chai').expect;
 
 describe('Route Patterns', () => {
-  it('should work with route parameter', done => {
+  it('should work with path parameter', done => {
     mockyeah.get('/service/:key');
 
     request.get('/service/exists').expect(200, done);
+  });
+
+  it.only('should expose path parameters to custom middleware as keyed object', done => {
+    let report = true;
+    mockyeah.get('/service/:one/:two/other/:three', (req, res) => {
+      try {
+        expect(req.params).to.deep.equal({
+          one: 'exists',
+          two: 'ok',
+          three: 'yes',
+          0: 'exists',
+          1: 'ok',
+          2: 'yes'
+        });
+      } catch (err) {
+        done(err);
+        report = false;
+      }
+      res.send();
+    });
+
+    request.get('/service/exists/ok/other/yes').expect(200, () => {
+      if (report) done();
+    });
+  });
+
+  it.only('should expose path parameters to custom middleware as indexed array', done => {
+    let report = true;
+    mockyeah.get('/service/:one/:two/other/:three', (req, res) => {
+      try {
+        expect(req.params[1]).to.equal('ok');
+      } catch (err) {
+        done(err);
+        report = false;
+      }
+      res.send();
+    });
+
+    request.get('/service/exists/ok/other/yes').expect(200, () => {
+      if (report) done();
+    });
   });
 
   it('should work with regular expression slash any count', done => {

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -12,7 +12,7 @@ describe('Route Patterns', () => {
     request.get('/service/exists').expect(200, done);
   });
 
-  it.only('should expose path parameters to custom middleware as keyed object', done => {
+  it('should expose path parameters to custom middleware as keyed object', done => {
     let report = true;
     mockyeah.get('/service/:one/:two/other/:three', (req, res) => {
       try {


### PR DESCRIPTION
This restores the ability to capture request path parameters (per Express) in custom middleware response handlers, post-refacto (https://github.com/ryanricard/mockyeah/pull/46), and closes https://github.com/ryanricard/mockyeah/issues/50.

http://expressjs.com/en/api.html#req.params
