### PR TITLE
refactor: restore custom middleware priority with immediate listen

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const async = require('async');
 const Logger = require('./lib/Logger');
 const RouteManager = require('./lib/RouteManager');
 
@@ -50,6 +51,16 @@ module.exports = function App(config) {
   });
 
   app.use(bodyParser.json());
+
+  app.middlewares = [];
+
+  app.use((req, res, next) => {
+    async.series(app.middlewares.map(middleware => cb => middleware(req, res, cb)), err => next(err));
+  });
+
+  app.use = middleware => {
+    app.middlewares.push(middleware);
+  };
 
   // Attach RouteManager to app object, the primary set of mockyeah API methods.
   app.routeManager = new RouteManager(app);

--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -29,10 +29,6 @@ function isRouteMatch(route1, route2) {
 }
 
 function listen() {
-  if (this.listening) return;
-
-  this.listening = true;
-
   this.app.all('*', (req, res, next) => {
     const route = this.routes.find(r => isRouteForRequest(r, req));
 
@@ -64,7 +60,7 @@ function RouteResolver(app) {
 
   this.routes = [];
 
-  this.listening = false;
+  listen.call(this);
 }
 
 RouteResolver.prototype.register = function register(method, path, response) {
@@ -84,9 +80,6 @@ RouteResolver.prototype.register = function register(method, path, response) {
   this.unregister([route]);
 
   this.routes.push(route);
-
-  // it is necessary to mount catch all route here to avoid overriding middleware
-  listen.call(this);
 
   return {
     expect: () => expectation.api()

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "web service"
   ],
   "devDependencies": {
-    "async": "^1.5.2",
     "chai": "^3.4.1",
     "dateformat": "^1.0.12",
     "eslint": "^1.10.3",
@@ -65,6 +64,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "async": "^1.5.2",
     "body-parser": "^1.15.2",
     "cors": "^2.7.1",
     "express": "^4.13.3",


### PR DESCRIPTION
This is a simple refactoring to support future features.

With the refactoring in https://github.com/ryanricard/mockyeah/pull/46, we decided to have mockyeah defer its server listen until a route was registered, so that the generic route handler didn't run before and intercept any custom middleware registered with `mockyeah.use`. This turns out to have been a short-sighted decision for upcoming requirements to proxy, since we'd like to be able to listen even without any route registration, to support pure proxying behavior as a baseline.

This refactoring restores the behavior of listening immediately, but still supports custom middleware, by capturing a reference to any custom middleware that are registered after initial default server instantiation, but prioritizing them at request-time to run before the route handler for mocked routes.

All tests are passing.
