### PR TITLE
feat: support proxying full urls, optionally mocking

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -56,11 +56,7 @@ module.exports = function App(config) {
   app.middlewares = [];
 
   app.use((req, res, next) => {
-    const callbacks = app.middlewares.map(middleware =>
-      cb => middleware(req, res, cb)
-    );
-
-    async.series(callbacks, next);
+    async.series(app.middlewares.map(middleware => cb => middleware(req, res, cb)), err => next(err));
   });
 
   app.use = middleware => {

--- a/app/index.js
+++ b/app/index.js
@@ -59,10 +59,6 @@ module.exports = function App(config) {
     async.series(app.middlewares.map(middleware => cb => middleware(req, res, cb)), err => next(err));
   });
 
-  app.use = middleware => {
-    app.middlewares.push(middleware);
-  };
-
   // Attach RouteManager to app object, the primary set of mockyeah API methods.
   app.routeManager = new RouteManager(app);
 

--- a/app/index.js
+++ b/app/index.js
@@ -80,8 +80,8 @@ module.exports = function App(config) {
     middleware(req, res, next);
   });
 
-  app.proxy = () => {
-    app.proxying = true;
+  app.proxy = (on = true) => {
+    app.proxying = on;
   };
 
   app.reset = () => {

--- a/app/index.js
+++ b/app/index.js
@@ -80,8 +80,8 @@ module.exports = function App(config) {
     middleware(req, res, next);
   });
 
-  app.proxy = (on = true) => {
-    app.proxying = on;
+  app.proxy = on => {
+    app.proxying = typeof on !== 'undefined' ? on : true;
   };
 
   app.reset = () => {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "web service"
   ],
   "devDependencies": {
-    "async": "^1.5.2",
     "chai": "^3.4.1",
     "dateformat": "^1.0.12",
     "eslint": "^1.10.3",
@@ -65,9 +64,12 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
+    "async": "^1.5.2",
     "body-parser": "^1.15.2",
     "cors": "^2.7.1",
     "express": "^4.13.3",
+    "http-proxy-middleware": "^0.17.4",
+    "is-absolute-url": "^2.1.0",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
     "path-to-regexp": "^2.1.0",

--- a/server/index.js
+++ b/server/index.js
@@ -26,9 +26,12 @@ module.exports = function Server(config, onStart) {
   });
 
   // Expose ability to stop server via API
-  const close = server.close.bind(server, function callback() {
-    app.log(['serve', 'exit'], 'Goodbye.');
-  });
+  const close = function close(cb) {
+    server.close(function callback() {
+      app.log(['serve', 'exit'], 'Goodbye.');
+      if (cb) cb();
+    });
+  };
 
   // Expose ability to implement middleware via API
   const use = function use() {
@@ -36,5 +39,10 @@ module.exports = function Server(config, onStart) {
   };
 
   // Construct and return mockyeah API
-  return Object.assign({ server }, app.routeManager, { use, config, close });
+  return Object.assign(
+    { server },
+    app.routeManager,
+    { proxy: app.proxy, reset: app.reset },
+    { use, config, close }
+  );
 };

--- a/test/integration/RouteProxyTest.js
+++ b/test/integration/RouteProxyTest.js
@@ -1,0 +1,58 @@
+'use strict';
+
+require('../TestHelper');
+const async = require('async');
+const express = require('express');
+const MockYeahServer = require('../../server');
+const supertest = require('supertest');
+
+describe('Route proxy', () => {
+  let mockyeah;
+  let proxiedApp;
+  let proxiedServer;
+  let request;
+
+  before(done => {
+    async.parallel([
+      cb => {
+        mockyeah = MockYeahServer({
+          port: 0
+        }, cb);
+        request = supertest(mockyeah.server);
+      },
+      cb => {
+        proxiedApp = express();
+        proxiedApp.get('/foo', (req, res) => res.sendStatus(200));
+        proxiedServer = proxiedApp.listen(8888, cb);
+      }
+    ], done);
+  });
+
+  after(done => {
+    async.parallel([
+      cb => mockyeah.close(cb),
+      cb => proxiedServer.close(cb)
+    ], done);
+  });
+
+  beforeEach(() => {
+    mockyeah.proxy();
+  });
+
+  afterEach(() => {
+    mockyeah.reset();
+  });
+
+  it('should support registering full URLs manually', done => {
+    mockyeah.get('/http://localhost:8888/foo', { text: 'bar', status: 500 });
+
+    async.series([
+      cb => supertest(proxiedApp).get('/foo').expect(200, cb),
+      cb => request.get('/http://localhost:8888/foo').expect(500, 'bar', cb)
+    ], done);
+  });
+
+  it('should support proxying other URLs', done => {
+    request.get('/http://localhost:8888/foo').expect(200, done);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,10 @@ event-emitter@~0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+eventemitter3@1.x.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -1248,6 +1252,22 @@ http-errors@1.6.2, http-errors@~1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
+http-proxy-middleware@^0.17.4:
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz#642e8848851d66f09d4f124912846dbaeb41b833"
+  dependencies:
+    http-proxy "^1.16.2"
+    is-glob "^3.1.0"
+    lodash "^4.17.2"
+    micromatch "^2.3.11"
+
+http-proxy@^1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.16.2.tgz#06dff292952bf64dbe8471fa9df73066d4f37742"
+  dependencies:
+    eventemitter3 "1.x.x"
+    requires-port "1.x.x"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1315,6 +1335,10 @@ irregular-plurals@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz#2ca9b033651111855412f16be5d77c62a458a766"
 
+is-absolute-url@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
+
 is-absolute@^0.2.3:
   version "0.2.6"
   resolved "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb"
@@ -1354,6 +1378,10 @@ is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
 
+is-extglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-finite@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
@@ -1371,6 +1399,12 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  dependencies:
+    is-extglob "^2.1.0"
 
 is-my-json-valid@^2.10.0:
   version "2.16.1"
@@ -1846,6 +1880,10 @@ lodash@^3.10.1, lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.2:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
@@ -1900,9 +1938,9 @@ methods@1.x, methods@~1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.3.7:
+micromatch@^2.3.11, micromatch@^2.3.7:
   version "2.3.11"
-  resolved "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
     arr-diff "^2.0.0"
     array-unique "^0.2.1"
@@ -2442,6 +2480,10 @@ request@^2.69.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+requires-port@1.x.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 resolve-dir@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
Adds support for proxying any path to mockyeah URL that looks like an absolute URL to the actual backend via `http-proxy-middleware` (see below for choice rationale). Any URL can be optionally mocked as a path to prevent a trip to backend for it, while still allowing the rest through. This allows for partial mocking of real backends, so you can point to mockyeah from a real application and get mocked responses for some requests, but don't have to mock out every possible URL for all APIs used by the app to get realistic behavior. Could come in handy for local development, regression testing, demos, etc. where backend APIs can't be relied on for consistent responses to cause specific application behaviors.

Proxying behavior is disabled by default, but explicitly enabled with `mockyeah.proxy()`, so as not to interfere with `mockyeah.record()` and `mockyeah.play()`. A tighter integration, and proxying by default, and from the CLI, may come in a future PR.

There might be a future use case for proxying to backend but partially mocking some responses with a custom transform function if they match a mocked path. We'll have to see how to integrate that with our proxy middleware - possibly via its `onProxyRes`, which might receive as an argument the same `res` object that's passed through our route middleware, where we could set setting the metadata for the transform) - or consider another solution at that time.

I decided to go with `http-proxy-middleware` for now, but could have considered `request` and it's streaming capabilities with server responses (which we already use as well for the recording feature) - I'm not sure which has a better story about capturing response data for persistence to file for later playback, and for future features like the transform capability discussed above, but I'm leaning toward `http-proxy-middleware`.

Includes changes from #57, as those were needed for this functionality.

Closes #57.


