### PR TITLE
refactor: fix no callback warning for record write file

### DIFF
--- a/app/lib/CaptureRecorder.js
+++ b/app/lib/CaptureRecorder.js
@@ -28,7 +28,7 @@ function CaptureRecorder(app, captureName) {
   return this;
 }
 
-function writeFile(filePath, data) {
+function writeFile(filePath, data, cb) {
   data = {
     method: data.request.method,
     url: data.url,
@@ -41,7 +41,7 @@ function writeFile(filePath, data) {
     }
   };
 
-  fs.writeFile(filePath, JSON.stringify(data, null, 2));
+  fs.writeFile(filePath, JSON.stringify(data, null, 2), cb);
 }
 
 function resolveFilePath(capturePath, url) {
@@ -61,9 +61,13 @@ CaptureRecorder.prototype.record = function record(req, res) {
     const filePath = resolveFilePath(this.capturePath, url);
     response.url = url;
     response.latency = now() - startTime;
-    writeFile(filePath, response);
-    this.app.log(['record', 'response', 'saved'], url);
-    ++this.count;
+    writeFile(filePath, response, () => {
+      if (error) return this.app.log(['record', 'response', 'error'], error);
+
+      this.app.log(['record', 'response', 'saved'], url);
+
+      ++this.count;
+    });
   }).pipe(res);
 };
 


### PR DESCRIPTION
Refactors to fix this Node deprecation warning in the console:
```
(node:42160) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```

This solves the issue for now and is intended to retain current behavior.

As an additional or future point of discussion, I'm not sure if it's best to continue to push these writes to the background and merely log errors asynchronously, or if we should consider bubbling the error up to Express - especially if we integrate the recording proxy feature with the generic proxying in the future (#58).
