### PR TITLE
fix: no fake root path

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -46,16 +46,14 @@ module.exports = function App(config) {
   // Provide user feedback when verbose output is enabled
   app.log('info', 'verbose output enabled', true);
 
-  app.get('/', (req, res) => {
-    res.send('Hello, mockyeah!');
-  });
-
   app.use(bodyParser.json());
 
   app.middlewares = [];
 
   app.use((req, res, next) => {
-    async.series(app.middlewares.map(middleware => cb => middleware(req, res, cb)), err => next(err));
+    async.series(app.middlewares.map(middleware => cb => middleware(req, res, cb)), err =>
+      next(err)
+    );
   });
 
   app.use = middleware => {

--- a/test/integration/ServerTest.js
+++ b/test/integration/ServerTest.js
@@ -4,10 +4,6 @@ const TestHelper = require('../TestHelper');
 const request = TestHelper.request;
 
 describe('Server', () => {
-  it('should respond to root http requests', done => {
-    request.get('/').expect(200, /Hello\, mockyeah\!/, done);
-  });
-
   it('should respond with a 404 for unknown paths', done => {
     request.get('/unknown/path').expect(404, done);
   });


### PR DESCRIPTION
This was interfering with users mounting responses on the root '/' path.
Broken since #46.