### PR TITLE
fix: normalize path trailing slashes

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -12,10 +12,19 @@ function isEqualMethod(method1, method2) {
   return m1 === 'all' || m2 === 'all' || m1 === m2;
 }
 
+const justSlashes = /^\/+$/;
+const trailingSlashes = /\/+$/;
+
+function normalizePathname(pathname) {
+  if (!pathname || justSlashes.test(pathname)) return '/';
+  // remove any trailing slashes
+  return pathname.replace(trailingSlashes, '');
+}
+
 function isRouteForRequest(route, req) {
   if (!isEqualMethod(req.method, route.method)) return false;
 
-  const pathname = parse(req.url, true).pathname;
+  const pathname = normalizePathname(parse(req.url, true).pathname);
 
   if (route.pathname !== '*' && !route.pathRegExp.test(pathname)) return false;
 
@@ -78,7 +87,7 @@ function RouteResolver(app) {
 RouteResolver.prototype.register = function register(method, path, response) {
   const route = { method, path, response };
 
-  route.pathname = parse(route.path, true).pathname;
+  route.pathname = normalizePathname(parse(route.path, true).pathname);
   const matchKeys = [];
   route.pathRegExp = pathToRegExp(route.pathname, matchKeys);
   route.matchKeys = matchKeys;

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -6,6 +6,86 @@ const request = TestHelper.request;
 const expect = require('chai').expect;
 
 describe('Route Patterns', () => {
+  describe('trailing slashes', () => {
+    it('should match when root mock and request use trailing slash', done => {
+      mockyeah.get('//');
+
+      request.get('//').expect(200, done);
+    });
+
+    it('should match when root mock but not request uses trailing slash', done => {
+      mockyeah.get('//');
+
+      request.get('/').expect(200, done);
+    });
+
+    it('should match when root request but not mock uses trailing slash', done => {
+      mockyeah.get('/');
+
+      request.get('//').expect(200, done);
+    });
+
+    it('should match when root mock uses trailing slash and request is blank', done => {
+      mockyeah.get('//');
+
+      request.get('').expect(200, done);
+    });
+
+    it('should match when root mock is blank and request uses trailing slash', done => {
+      mockyeah.get('');
+
+      request.get('//').expect(200, done);
+    });
+
+    it('should match when root mock uses slash and request is blank', done => {
+      mockyeah.get('/');
+
+      request.get('').expect(200, done);
+    });
+
+    it('should match when root mock is blank and request uses slash', done => {
+      mockyeah.get('');
+
+      request.get('/').expect(200, done);
+    });
+
+    it('should match when mock and request use trailing slash', done => {
+      mockyeah.get('/foo/bar/');
+
+      request.get('/foo/bar/').expect(200, done);
+    });
+
+    it('should match when mock but not request uses trailing slash', done => {
+      mockyeah.get('/foo/bar/');
+
+      request.get('/foo/bar').expect(200, done);
+    });
+
+    it('should match when request but not mock uses trailing slash', done => {
+      mockyeah.get('/foo/bar');
+
+      request.get('/foo/bar/').expect(200, done);
+    });
+
+    it('should match when mock and request use trailing slashes', done => {
+      mockyeah.get('/foo/bar//');
+
+      request.get('/foo/bar///').expect(200, done);
+    });
+
+    it('should match when mock but not request uses trailing slashes', done => {
+      mockyeah.get('/foo/bar//');
+
+      request.get('/foo/bar').expect(200, done);
+    });
+
+    it('should match when request but not mock uses trailing slashes', done => {
+      mockyeah.get('/foo/bar');
+
+      request.get('/foo/bar//').expect(200, done);
+    });
+  });
+
   it('should work with path parameter', done => {
     mockyeah.get('/service/:key');
 


### PR DESCRIPTION
Fixes a regression from #46 where trailing slashes were not being handled the same as before. They should be ignored when matching a mock path to a request.