### PR TITLE
fix: don't pass non-absolute url paths to proxy middleware

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const proxy = require('http-proxy-middleware');
 const async = require('async');
+const isAbsoluteUrl = require('is-absolute-url');
 const Logger = require('./lib/Logger');
 const RouteManager = require('./lib/RouteManager');
 
@@ -68,9 +69,14 @@ module.exports = function App(config) {
     }
 
     const reqPath = req.path.replace(/^\//, '');
-    const target = reqPath;
+
+    if (!isAbsoluteUrl(reqPath)) {
+      next();
+      return;
+    }
+
     const middleware = proxy({
-      target,
+      target: reqPath,
       changeOrigin: true,
       logLevel: 'silent', // TODO: Sync with mockyeah settings.
       ignorePath: true


### PR DESCRIPTION
Fixes a bug from #58 where a non-mocked, non-absolute URL was getting passed into the proxy logic and failing rather than returning 404.