### PR TITLE
chore: remove node v4 from tests & docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "8"
   - "6"
-  - "4"
 branches:
   only:
     - master

--- a/docs/pages/Contributing.md
+++ b/docs/pages/Contributing.md
@@ -2,7 +2,7 @@
 
 **Installing project and dependencies:**
 
-mockyeah was built and tested with Node v4.2.3. Installing mockyeah:
+mockyeah was built and tested with Node v6+. Installing mockyeah:
 
 ```shell
 # download project
@@ -10,7 +10,7 @@ $ git clone git@github.com:ryanricard/mockyeah.git
 $ cd mockyeah
 
 # install proper Node version
-$ nvm install v4.2.3
+$ nvm install v6
 $ nvm use
 
 # if tests pass, you're good to go


### PR DESCRIPTION
Because we no longer support it since https://github.com/ryanricard/mockyeah/pull/72.

In the future, we can transpile down, if needed.