### PR TITLE
chore: make record less async for tests

### DIFF
--- a/app/lib/CaptureRecorder.js
+++ b/app/lib/CaptureRecorder.js
@@ -28,7 +28,7 @@ function CaptureRecorder(app, captureName) {
   return this;
 }
 
-function writeFile(filePath, data, cb) {
+function writeFile(filePath, data) {
   data = {
     method: data.request.method,
     url: data.url,
@@ -41,7 +41,7 @@ function writeFile(filePath, data, cb) {
     }
   };
 
-  fs.writeFile(filePath, JSON.stringify(data, null, 2), cb);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
 }
 
 function resolveFilePath(capturePath, url) {
@@ -61,13 +61,15 @@ CaptureRecorder.prototype.record = function record(req, res) {
     const filePath = resolveFilePath(this.capturePath, url);
     response.url = url;
     response.latency = now() - startTime;
-    writeFile(filePath, response, () => {
-      if (error) return this.app.log(['record', 'response', 'error'], error);
+    try {
+      writeFile(filePath, response);
 
       this.app.log(['record', 'response', 'saved'], url);
 
       ++this.count;
-    });
+    } catch (err) {
+      this.app.log(['record', 'response', 'error'], err);
+    }
   }).pipe(res);
 };
 


### PR DESCRIPTION
Tests are failing intermittently since record wasn't guaranteed to write recorded request mocks to the filesystem immediately before requests were made expecting the fixture files to exist.
This may not completely solve the issue, but it at least makes the file recording slightly more synchronous to hopefully reduce its incidence.