### PR TITLE
feat: support partial body matches

### DIFF
--- a/app/lib/RouteResolver.js
+++ b/app/lib/RouteResolver.js
@@ -41,7 +41,7 @@ function isRouteForRequest(route, req) {
 
   if (route.body) {
     // TODO: See what `req.body` looks like with different request content types.
-    const matchesBody = _.isEqual(route.body, req.body);
+    const matchesBody = _.isMatch(req.body, route.body);
     return matchesBody;
   }
 

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -238,7 +238,7 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
-  it('should match partial request body', done => {
+  it('should match with partial request body', done => {
     mockyeah.post({
       path: '/foo',
       body: {

--- a/test/integration/RoutePatternTest.js
+++ b/test/integration/RoutePatternTest.js
@@ -238,6 +238,30 @@ describe('Route Patterns', () => {
       .expect(200, done);
   });
 
+  it('should match partial request body', done => {
+    mockyeah.post({
+      path: '/foo',
+      body: {
+        bar: 'yes',
+        nest: {
+          deep: 'too'
+        }
+      }
+    });
+
+    request
+      .post('/foo')
+      .send({
+        bar: 'yes',
+        nest: {
+          deep: 'too',
+          also: 'more'
+        },
+        and: 'this'
+      })
+      .expect(200, done);
+  });
+
   it('should fail to match when different request body', done => {
     mockyeah.post({
       path: '/nope',


### PR DESCRIPTION
This changes the body matching function from `_.isEqual` to `_.isMatch` to support partial matches. See the new unit test for an example. This gives us power and flexibility (which will be extended later) to match a whole class of requests with a single mock, ignoring specific fields if we choose to, such as a specific item ID in a REST API.